### PR TITLE
🪲fix Safari compatibility (no more Youtube api)

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -10,13 +10,4 @@ declare namespace App {
 	// interface Platform {}
 }
 
-declare interface Window {
-	/**
-	 * A function called by the youtube API once the page is done loading the javascript file
-	 * https://developers.google.com/youtube/iframe_api_reference#Requirements
-	 * @returns void
-	 */
-	onYouTubeIframeAPIReady: () => void;
-}
-
 type ThumbnailQuality = 'mqdefault' | 'hqdefault' | 'sddefault' | 'maxresdefault';

--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { tick } from 'svelte';
 	import PlayButton from './PlayButton.svelte';
 
 	/**
@@ -28,8 +27,6 @@
 	let embedUrl = '';
 	let thumbnailUrl = '';
 	let youtubeUrl = '';
-	let needsYTApiForAutoplay = false;
-	let YTApiContainer: HTMLDivElement;
 
 	const params = new URLSearchParams({ autoplay: '1', playsinline: '1' });
 
@@ -38,39 +35,9 @@
 	$: youtubeUrl = `https://www.youtube.com/watch?v=${id}`;
 
 	async function handleClick(event: MouseEvent) {
-		needsYTApiForAutoplay = getYTApiRequirements();
 		if (event.metaKey || event.ctrlKey) return;
 		event.preventDefault();
 		showVideo = true;
-
-		if (needsYTApiForAutoplay) {
-			await tick();
-			window.onYouTubeIframeAPIReady = createYoutubeEmbed();
-		}
-	}
-
-	function getYTApiRequirements() {
-		// navigator.vendor seems to be deprecated : https://developer.mozilla.org/en-US/docs/Web/API/Navigator/vendor
-		return (
-			window.navigator?.vendor.includes('Apple') || window.navigator?.userAgent.includes('Mobi')
-		);
-	}
-
-	function createYoutubeEmbed() {
-		return () => {
-			const paramsObj = Object.fromEntries(params.entries());
-			new window.YT.Player(YTApiContainer, {
-				width: '100%',
-				host: 'https://www.youtube-nocookie.com',
-				videoId: id,
-				playerVars: paramsObj,
-				events: {
-					onReady: (event) => {
-						event.target.playVideo();
-					}
-				}
-			});
-		};
 	}
 </script>
 
@@ -83,17 +50,12 @@
 	on:click={handleClick}
 >
 	{#if showVideo}
-		{#if needsYTApiForAutoplay}
-			<script async={true} src="https://www.youtube.com/iframe_api"></script>
-			<div bind:this={YTApiContainer} />
-		{:else}
-			<iframe
-				title={title || 'YouTube video'}
-				src={embedUrl}
-				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-				allowfullscreen
-			/>
-		{/if}
+		<iframe
+			title={title || 'YouTube video'}
+			src={embedUrl}
+			allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+			allowfullscreen
+		/>
 	{:else}
 		{#if showTitle && title}
 			<div class="title">{title}</div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,17 +2,27 @@
 	import { Youtube } from '$lib/index';
 </script>
 
-<h1>svelte-youtube-lite demo</h1>
+<div class="page">
+	<h1>svelte-youtube-lite demo</h1>
 
-<h2>Minimal example</h2>
-<Youtube id="QH2-TGUlwu4" />
+	<h2>Minimal example</h2>
+	<Youtube id="QH2-TGUlwu4" />
 
-<h2>With low quality thumbnail</h2>
-<Youtube id="QH2-TGUlwu4" thumbnail="mqdefault" />
+	<h2>With low quality thumbnail</h2>
+	<Youtube id="QH2-TGUlwu4" thumbnail="mqdefault" />
 
-<h2>With custom iframe title</h2>
-<p><em>(YouTube iframe API fallback uses the videos title as iframe title)</em></p>
-<Youtube id="QH2-TGUlwu4" title="Cute cat video" />
+	<h2>With custom iframe title</h2>
+	<p><em>(YouTube iframe API fallback uses the videos title as iframe title)</em></p>
+	<Youtube id="QH2-TGUlwu4" title="Cute cat video" />
 
-<h2>Without title</h2>
-<Youtube id="QH2-TGUlwu4" showTitle={false} />
+	<h2>Without title</h2>
+	<Youtube id="QH2-TGUlwu4" showTitle={false} />
+</div>
+
+<style>
+	.page {
+		max-width: 608px;
+		margin-left: auto;
+		margin-right: auto;
+	}
+</style>


### PR DESCRIPTION
Fixed the potential pb with Safari.
![image](https://user-images.githubusercontent.com/849019/229835672-c9291b91-d99a-40c7-b550-af5cd3cfbaa2.png)

It cannot be replicated easily, the demo page works well but in real conditions, the iframe is missing the svelte class only in Safari <= 16.
https://www.francebleu.fr/musique/concerts-live/le-journal-du-njp-du-11-octobre-emile-parisien-naya-et-octave-noir-1507715529

The code had a Safari special behaviour, calling the Youtube API to start the video, but it did not work.
Removing this behaviour seems to fix the bug.
