### PR TITLE
Slot for play button to allow setting accessibility attributes

### DIFF
--- a/src/lib/PlayButton.svelte
+++ b/src/lib/PlayButton.svelte
@@ -1,4 +1,9 @@
-<button class="PlayButton" />
+<script lang="ts">
+	export let ariaLabel: string = 'Play video';
+	export let title: string = 'Play video';
+</script>
+
+<button class="PlayButton" aria-label={ariaLabel} title={title} />
 
 <style>
 	.PlayButton {

--- a/src/lib/Youtube.svelte
+++ b/src/lib/Youtube.svelte
@@ -62,7 +62,11 @@
 		{#if showTitle && title}
 			<div class="title">{title}</div>
 		{/if}
-		<PlayButton />
+		{#if $$slots.playButton}
+			<slot name="playButton" />
+		{:else}
+			<PlayButton />
+		{/if}
 	{/if}
 </a>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,7 +26,7 @@
 
 	<h2>With custom button</h2>
 	<Youtube id="aYtE6XE6b_s" showTitle={false}>
-    <button slot="playButton">A completely custom button</button>
+    <button slot="playButton" style="position: absolute; left: 50%; top: 50%; transform: translate3d(-50%, -50%, 0);">A completely custom button</button>
   </Youtube>
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -26,9 +26,7 @@
 
 	<h2>With custom button</h2>
 	<Youtube id="aYtE6XE6b_s" showTitle={false}>
-    <slot name="playButton">
-      <button>A completely custom button</button>
-    </slot>
+    <button slot="playButton">A completely custom button</button>
   </Youtube>
 </div>
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,9 +21,7 @@
 
   <h2>With custom aria label button</h2>
 	<Youtube id="aYtE6XE6b_s" showTitle={false}>
-    <slot name="playButton">
-      <PlayButton ariaLabel="Custom play button" />
-    </slot>
+    <PlayButton slot="playButton" ariaLabel="Custom play button" />
   </Youtube>
 
 	<h2>With custom button</h2>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script>
 	import Youtube from '$lib/Youtube.svelte';
+	import PlayButton from '$lib/PlayButton.svelte';
 </script>
 
 <div class="page">
@@ -17,6 +18,20 @@
 
 	<h2>Without title</h2>
 	<Youtube id="aYtE6XE6b_s" showTitle={false} />
+
+  <h2>With custom aria label button</h2>
+	<Youtube id="aYtE6XE6b_s" showTitle={false}>
+    <slot name="playButton">
+      <PlayButton ariaLabel="Custom play button" />
+    </slot>
+  </Youtube>
+
+	<h2>With custom button</h2>
+	<Youtube id="aYtE6XE6b_s" showTitle={false}>
+    <slot name="playButton">
+      <button>A completely custom button</button>
+    </slot>
+  </Youtube>
 </div>
 
 <style>


### PR DESCRIPTION
# Overview

Adds so that you can override the play button with accessibility attributes as you need.

Example usage (added to example page):

```svelte
<h2>With custom aria label button</h2>
<Youtube id="aYtE6XE6b_s" showTitle={false}>
  <slot name="playButton">
    <PlayButton ariaLabel="Custom play button" />
  </slot>
</Youtube>

<h2>With custom button</h2>
<Youtube id="aYtE6XE6b_s" showTitle={false}>
  <slot name="playButton">
    <button>A completely custom button</button>
  </slot>
</Youtube>
```

## Why

Otherwise it can drag down the google page score for accessibility, and of course, for the sake of those needing accessibility hints.